### PR TITLE
Feat/create user objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/socket.io": "^2.1.11",
     "dotenv": "^8.2.0",
     "socket.io": "^2.3.0",
+    "unique-names-generator": "^4.3.1",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,9 +44,12 @@
   "dependencies": {
     "@bitauth/libauth": "^1.17.1",
     "@types/socket.io": "^2.1.11",
+    "bufferutil": "^4.0.1",
     "dotenv": "^8.2.0",
+    "nodemon": "^2.0.6",
     "socket.io": "^2.3.0",
     "unique-names-generator": "^4.3.1",
+    "utf-8-validate": "^5.0.2",
     "uuid": "^8.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Added base functionality for users in parties. While socket.io has some basic data which tracks users in rooms, we'll need to keep track of usernames and images.

- **What is the current behavior?** (You can also link to an open issue here)
None. I'm building the foundation of our backend. New functions for creating and removing users was added. These can be reused in future events.

- **What is the new behavior (if this is a feature change)?**
Rooms now store the usernames and images of party members. When a user joins a room, a new `User` object is added to the room. When a user leaves their `User` object is removed from the room. The same thing happens when a room is either created or destroyed (with a `Room` object). 

- **Other information**:
N/A I'll want to add some test cases, but I'm unsure where those go and how to create them.
