### PR TITLE
feat: generate random name + avatar

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
   },
   "dependencies": {
     "@bitauth/libauth": "^1.17.1",
+    "@dicebear/avatars": "^4.2.5",
+    "@dicebear/avatars-identicon-sprites": "^4.2.5",
     "@prisma/client": "^2.9.0",
     "@types/express": "^4.17.8",
     "@types/joi": "^14.3.4",
@@ -67,8 +69,10 @@
     "joi": "^17.3.0",
     "lodash": "^4.17.20",
     "mysql": "^2.18.1",
+    "nodemon": "^2.0.6",
     "query-string": "^6.13.6",
     "socket.io": "^2.3.0",
+    "unique-names-generator": "^4.3.1",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,7 +45,7 @@ model users {
   socket_id  String
   is_active  Boolean?
   party_id   Int?
-  name       String?
+  name       String
   avatar_url String?
   created_at DateTime?  @default(now())
   updated_at DateTime?  @default(now())

--- a/src/lib/services/party.ts
+++ b/src/lib/services/party.ts
@@ -63,6 +63,7 @@ export default class Party {
     for (const user of party.users) {
       usernames.push(user.name);
     }
+    console.log(usernames);
     return new Set(usernames);
   }
 

--- a/src/lib/services/party.ts
+++ b/src/lib/services/party.ts
@@ -41,4 +41,29 @@ export default class Party {
       },
     });
   }
+
+  static async getPartyWithUsers({ partyHash }: GetParams) {
+    const party = dbClient.parties.findFirst({
+      where: {
+        hash: partyHash,
+      },
+      include: {
+        users: true,
+      },
+    });
+    return party;
+  }
+
+  static async getCurrentUsernames({ partyHash }: GetParams): Promise<Set<string>> {
+    const party = await Party.getPartyWithUsers({
+      partyHash: partyHash,
+    });
+    const usernames: string[] = [];
+    console.log(party);
+    for (const user of party.users) {
+      usernames.push(user.name);
+    }
+    return new Set(usernames);
+  }
+
 }

--- a/src/lib/services/party.ts
+++ b/src/lib/services/party.ts
@@ -10,6 +10,10 @@ interface GetParams {
   partyHash: string;
 }
 
+interface SearchUsersParams {
+  partyHash: string;
+}
+
 export default class Party {
   static async create({ watchUrl }: CreateParams) {
     const hash = uuidv4();
@@ -42,25 +46,14 @@ export default class Party {
     });
   }
 
-  static async getPartyWithUsers({ partyHash }: GetParams) {
+  static async searchUsers({ partyHash }: SearchUsersParams) {
     return dbClient.parties.findFirst({
       where: {
         hash: partyHash,
       },
-      include: {
+      select: {
         users: true,
       },
     });
-  }
-
-  static async getCurrentUsernames({ partyHash }: GetParams): Promise<Set<string>> {
-    const party = await Party.getPartyWithUsers({
-      partyHash: partyHash,
-    });
-    const usernames: string[] = [];
-    for (const user of party.users) {
-      usernames.push(user.name);
-    }
-    return new Set(usernames);
   }
 }

--- a/src/lib/services/users.ts
+++ b/src/lib/services/users.ts
@@ -16,7 +16,6 @@ interface JoinPartyParams {
 }
 
 export default class Users {
-
   static async create({ socketId }: CreateParams) {
     const user = await dbClient.users.create({
       data: {
@@ -53,13 +52,12 @@ export default class Users {
     if (!party) throw new Error('Fatal: No party found');
 
     const username: string = await Users.generateName(hash);
-    const image: string = Users.generateImage(username)
     await dbClient.users.update({
       where: {
         socket_id_is_active_unique: {
           socket_id: socketId,
           is_active: true,
-        }, 
+        },
       },
       data: {
         parties: {
@@ -68,7 +66,7 @@ export default class Users {
           },
         },
         name: username,
-        avatar_url: image,
+        avatar_url: Users.generateImage(username),
       },
     });
     return party;

--- a/src/lib/services/users.ts
+++ b/src/lib/services/users.ts
@@ -56,7 +56,7 @@ export default class Users {
     if (!party) throw new Error('Fatal: No party found');
 
     const username: string = await Users.generateName(hash);
-    
+    console.log(socketId);
     dbClient.users.update({
       where: {
         socket_id_is_active_unique: {
@@ -74,7 +74,6 @@ export default class Users {
         avatar_url: Users.generateImage(username),
       },
     });
-
     return party;
   }
 

--- a/src/lib/services/users.ts
+++ b/src/lib/services/users.ts
@@ -22,6 +22,7 @@ export default class Users {
       data: {
         is_active: true,
         socket_id: socketId,
+        name: "temp",
       },
     });
 

--- a/src/lib/socket/server.ts
+++ b/src/lib/socket/server.ts
@@ -26,9 +26,8 @@ export default class Manager {
   }
 
   listen() {
-    this.server.on('connection', (socket) => {
-      // Persist the new user
-      UserService.create({
+    this.server.on('connection', async (socket) => {
+      await UserService.create({
         socketId: socket.id,
       });
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Database now stores usernames and user images in the users table. Username is randomly generated and checked for collisions with other names in the party. User image is a url to an image hosted by Dicebear.

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
