### PR TITLE
feat: forward video events to other users in party

### DIFF
--- a/src/lib/socket/events.ts
+++ b/src/lib/socket/events.ts
@@ -4,4 +4,12 @@ export enum SocketEvents {
   SEND_MESSAGE = 'send_message',
   NEW_MESSAGE = 'new_message',
   GET_MESSAGES = 'get_messages',
+  VIDEO_EVENT = 'video_event',
+}
+
+export enum VideoSocketEvents {
+  VIDEO_PLAY = 'video_play',
+  VIDEO_PAUSE = 'video_pause',
+  VIDEO_SEEKED = 'video_seeked',
+  VIDEO_PROGRESS = 'video_progress',
 }

--- a/src/lib/socket/server.ts
+++ b/src/lib/socket/server.ts
@@ -3,7 +3,7 @@ import { Server } from 'http';
 import { Party, User } from '@app/lib/models';
 import MessageService from '@app/lib/services/messages';
 import UserService from '@app/lib/services/users';
-import { Message } from '@app/lib/types';
+import { Message, VideoEvent } from '@app/lib/types';
 import io from 'socket.io';
 
 import { SocketEvents } from './events';
@@ -23,6 +23,7 @@ export default class Manager {
       [SocketEvents.JOIN_PARTY, this.onSocketJoinParty],
       [SocketEvents.SEND_MESSAGE, this.onSocketSendMessage],
       [SocketEvents.GET_MESSAGES, this.onSocketGetMessages],
+      [SocketEvents.VIDEO_EVENT, this.onSocketVideoEvent],
     ];
   }
 
@@ -93,4 +94,12 @@ export default class Manager {
       messages,
     });
   }
+
+  onSocketVideoEvent(
+    this: io.Socket,
+    data: VideoEvent,
+  ) {
+    this.to(data.partyHash).emit(SocketEvents.VIDEO_EVENT, data.eventData);
+  }
+
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,1 +1,2 @@
 export * from './message';
+export * from './video';

--- a/src/lib/types/video.ts
+++ b/src/lib/types/video.ts
@@ -1,0 +1,15 @@
+import { VideoSocketEvents } from '@app/lib/socket/events';
+
+export interface VideoEvent {
+  partyHash: string;
+  eventData: VideoEventData;
+}
+
+export interface VideoEventData {
+  isHost: boolean;
+  paused: boolean;
+  currentTime: number;
+  playbackRate: number;
+  duration: number;
+  eventType: VideoSocketEvents;
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **What is the current behavior?** (You can also link to an open issue here)
Forward video events to other users in party

- **Other information**:
Video events emitted by a user are transferred to everyone else in the party except the emitting user. There is client side logic at the moment so that only the host sends events, and only non-hosts are affected by them.

Here is the corresponding PR for this PR to have any use: https://github.com/rkrishn7/couchsync/pull/16
